### PR TITLE
Refactor: Replace Debug.Log with custom Logger

### DIFF
--- a/Assets/Scripts/Core/Events/EventBus.cs
+++ b/Assets/Scripts/Core/Events/EventBus.cs
@@ -299,7 +299,7 @@ public static class EventBus
     {
         if (EnableDetailedLogging)
         {
-            Debug.Log($"[EventBus] {message}");
+            Logger.LogInfo($"[EventBus] {message}", Logger.LogCategory.General);
         }
     }
 
@@ -307,7 +307,7 @@ public static class EventBus
     {
         if (EnableDetailedLogging || EnableErrorLogging)
         {
-            Debug.LogWarning($"[EventBus] {message}");
+            Logger.LogWarning($"[EventBus] {message}", Logger.LogCategory.General);
         }
     }
 
@@ -315,7 +315,7 @@ public static class EventBus
     {
         if (EnableErrorLogging)
         {
-            Debug.LogError($"[EventBus] {message}");
+            Logger.LogError($"[EventBus] {message}", Logger.LogCategory.General);
         }
     }
 

--- a/Assets/Scripts/Data/Models/LocationActivity.cs
+++ b/Assets/Scripts/Data/Models/LocationActivity.cs
@@ -175,21 +175,21 @@ public class LocationActivity
         // Check if we have a valid ActivityReference
         if (ActivityReference == null)
         {
-            Debug.LogError($"LocationActivity: ActivityReference is null!");
+            Logger.LogError($"LocationActivity: ActivityReference is null!", Logger.LogCategory.General);
             return false;
         }
 
         // Check if the referenced activity is valid
         if (!ActivityReference.IsValid())
         {
-            Debug.LogError($"LocationActivity: ActivityReference '{ActivityReference.ActivityID}' is not valid!");
+            Logger.LogError($"LocationActivity: ActivityReference '{ActivityReference.ActivityID}' is not valid!", Logger.LogCategory.General);
             return false;
         }
 
         // Check if we have at least one valid variant
         if (ActivityVariants == null || ActivityVariants.Count == 0)
         {
-            Debug.LogError($"LocationActivity '{ActivityId}': No activity variants assigned!");
+            Logger.LogError($"LocationActivity '{ActivityId}': No activity variants assigned!", Logger.LogCategory.General);
             return false;
         }
 
@@ -205,7 +205,7 @@ public class LocationActivity
 
         if (!hasValidVariant)
         {
-            Debug.LogError($"LocationActivity '{ActivityId}': No valid variants found!");
+            Logger.LogError($"LocationActivity '{ActivityId}': No valid variants found!", Logger.LogCategory.General);
             return false;
         }
 

--- a/Assets/Scripts/Data/ScriptableObjects/ItemDefinition.cs
+++ b/Assets/Scripts/Data/ScriptableObjects/ItemDefinition.cs
@@ -111,19 +111,19 @@ public class ItemDefinition : ScriptableObject
     {
         if (string.IsNullOrEmpty(ItemID))
         {
-            Debug.LogError($"ItemDefinition '{name}': ItemID is empty!");
+            Logger.LogError($"ItemDefinition '{name}': ItemID is empty!", Logger.LogCategory.General);
             return false;
         }
 
         if (IsStackable && MaxStackSize <= 0)
         {
-            Debug.LogError($"ItemDefinition '{ItemID}': IsStackable is true but MaxStackSize is {MaxStackSize}!");
+            Logger.LogError($"ItemDefinition '{ItemID}': IsStackable is true but MaxStackSize is {MaxStackSize}!", Logger.LogCategory.General);
             return false;
         }
 
         if (IsBackpack() && InventorySlots <= 0)
         {
-            Debug.LogWarning($"ItemDefinition '{ItemID}': Backpack has {InventorySlots} inventory slots!");
+            Logger.LogWarning($"ItemDefinition '{ItemID}': Backpack has {InventorySlots} inventory slots!", Logger.LogCategory.General);
         }
 
         return true;

--- a/Assets/Scripts/Data/ScriptableObjects/MapLocationDefinition.cs
+++ b/Assets/Scripts/Data/ScriptableObjects/MapLocationDefinition.cs
@@ -179,7 +179,7 @@ public class MapLocationDefinition : ScriptableObject
 
         if (errors.Count > 0)
         {
-            Debug.LogError($"MapLocationDefinition '{name}' validation failed:\n{string.Join("\n", errors)}");
+            Logger.LogError($"MapLocationDefinition '{name}' validation failed:\n{string.Join("\n", errors)}", Logger.LogCategory.General);
             return false;
         }
 

--- a/Assets/Scripts/Debug/RuntimePlayerDataFixer.cs
+++ b/Assets/Scripts/Debug/RuntimePlayerDataFixer.cs
@@ -182,9 +182,9 @@ public class RuntimePlayerDataFixer : MonoBehaviour
         UpdateStatusText(diagnosis);
 
         // Also log to console for more details
-        Debug.Log("=== RUNTIME DIAGNOSTIC ===");
-        Debug.Log(diagnosis.Replace("\n", " | "));
-        Debug.Log("=== END DIAGNOSTIC ===");
+        Logger.LogInfo("=== RUNTIME DIAGNOSTIC ===", Logger.LogCategory.General);
+        Logger.LogInfo(diagnosis.Replace("\n", " | "), Logger.LogCategory.General);
+        Logger.LogInfo("=== END DIAGNOSTIC ===", Logger.LogCategory.General);
     }
 
     public void RepairTravelState()
@@ -213,7 +213,7 @@ public class RuntimePlayerDataFixer : MonoBehaviour
             dataManager?.ForceSave();
 
             UpdateStatusText($"SUCCESS: Etat voyage repare!\nSupprime: {oldDest}");
-            Debug.Log($"RuntimeFixer: Repaired travel state - removed destination '{oldDest}'");
+            Logger.LogInfo($"RuntimeFixer: Repaired travel state - removed destination '{oldDest}'", Logger.LogCategory.General);
         }
         else
         {
@@ -242,7 +242,7 @@ public class RuntimePlayerDataFixer : MonoBehaviour
             dataManager?.ForceSave();
 
             UpdateStatusText($"SUCCESS: Activite arretee!\nSupprime: {oldActivity}");
-            Debug.Log($"RuntimeFixer: Repaired activity state - stopped '{oldActivity}'");
+            Logger.LogInfo($"RuntimeFixer: Repaired activity state - stopped '{oldActivity}'", Logger.LogCategory.General);
         }
         else
         {
@@ -297,14 +297,14 @@ public class RuntimePlayerDataFixer : MonoBehaviour
             report += "\n   • Voyager vers d'autres POI";
             report += "\n   • Commencer des activites";
 
-            Debug.Log("RuntimeFixer: Full repair completed with changes");
+            Logger.LogInfo("RuntimeFixer: Full repair completed with changes", Logger.LogCategory.General);
         }
         else
         {
             report += "INFO: Aucune reparation necessaire\n";
             report += "Tout etait deja OK!";
 
-            Debug.Log("RuntimeFixer: Full repair completed - no issues found");
+            Logger.LogInfo("RuntimeFixer: Full repair completed - no issues found", Logger.LogCategory.General);
         }
 
         UpdateStatusText(report);
@@ -320,7 +320,7 @@ public class RuntimePlayerDataFixer : MonoBehaviour
         // Also log important messages
         if (text.Contains("SUCCESS") || text.Contains("PROBLEME"))
         {
-            Debug.Log($"RuntimePlayerDataFixer: {text.Replace("\n", " | ")}");
+            Logger.LogInfo($"RuntimePlayerDataFixer: {text.Replace("\n", " | ")}", Logger.LogCategory.General);
         }
     }
 


### PR DESCRIPTION
I replaced all instances of Debug.Log, Debug.LogWarning, and Debug.LogError with their respective Logger.LogInfo, Logger.LogWarning, and Logger.LogError calls in runtime scripts under Assets/Scripts/.

This change centralizes logging behavior and allows for more control over log levels and categories.

Debug calls within #if UNITY_EDITOR blocks were intentionally preserved to maintain editor-specific logging.

I modified a total of 5 files, making 16 replacements:
- Assets/Scripts/Core/Events/EventBus.cs (3)
- Assets/Scripts/Data/Models/LocationActivity.cs (4)
- Assets/Scripts/Data/ScriptableObjects/ItemDefinition.cs (3)
- Assets/Scripts/Data/ScriptableObjects/MapLocationDefinition.cs (1)
- Assets/Scripts/Debug/RuntimePlayerDataFixer.cs (8)